### PR TITLE
Call The Address Remove method & allow deleting an expired record

### DIFF
--- a/pkg/worker/table.go
+++ b/pkg/worker/table.go
@@ -131,15 +131,12 @@ func (s *IPAddressSet) Remove(addr netip.Addr) {
 	}
 }
 
-// Check if an IPv6 address exists in the set and is not expired.
+// Check if an IPv6 address exists in the set weather or not it is expired.
 func (s *IPAddressSet) Contains(addr netip.Addr) bool {
 	s.addressesMapMutex.RLock()
-	info, ok := s.addresses[addr]
+	_, ok := s.addresses[addr]
 	s.addressesMapMutex.RUnlock()
-	if !ok {
-		return false
-	}
-	return time.Now().Before(info.GetExpiration())
+	return ok
 }
 
 func (s *IPAddressSet) PrettyPrint(tabSize int) string {

--- a/pkg/worker/worker.go
+++ b/pkg/worker/worker.go
@@ -96,6 +96,7 @@ func (w *Worker) StartInterfaceAddr(iface net.Interface, addr netip.Addr) {
 	onFoundLinkLayerAddr := func(hostAddr netip.Addr, linkLayerAddr net.HardwareAddr) {
 		onExpiration := func(info *IPAddressInfo, attempt int) {
 			address := info.GetAddress()
+
 			if attempt == 0 {
 				w.logger.Infow("host expired",
 					zap.String("ipv6", netip.AddrFrom16(address.As16()).String()),
@@ -128,6 +129,9 @@ func (w *Worker) StartInterfaceAddr(iface net.Interface, addr netip.Addr) {
 				w.logger.Errorw("unable to ping, connection not available",
 					zap.String("ipv6", address.String()),
 				)
+			}
+			if time.Now().After(info.GetExpiration()) {
+				w.Table.macs[linkLayerAddr.String()].Remove(hostAddr)
 			}
 		}
 		existing := w.Table.Add(linkLayerAddr, hostAddr, w.ttl, onExpiration)


### PR DESCRIPTION
Add Calling the Remove method on the IPAddressSet object to remove an expired address.
Removing the expiration check from the Contains method because that always returns false when an address is expired, thus always preventing it to be removed. Removing this should be ok for the Add method because if an expired record exists, it can just be updated/revived.